### PR TITLE
Update release instructions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ test-results
 .eslintcache
 .direnv
 playwright*.tgz
+/tmp/

--- a/README.rwx.md
+++ b/README.rwx.md
@@ -16,21 +16,29 @@ Our `main` branch tracks upstream's `main`.
 
 ### Releasing playwright-test-abq
 
-Update `version` in the root `package.json`.
+Update the versions in [abq/version.ts](./packages/playwright-test/src/abq/version.ts).
+`testFrameworkVersion` should be the `version` from the [root package.json](./package.json).
+`adapterVersion` should be the ABQ version to release.
 
-Update the versions in [abq/version.ts](./packages/playwright-test/src/abq/version.ts) to match.
+Commit the resulting [abq/version.ts](./packages/playwright-test/src/abq/version.ts) changes.
 
-Commit the resulting `packages/*/package.json` changes.
+Perform the release from the `abq/release-*` branch.
 
-Perform the release from the `abq/release-*` branch, after `package.json` versions
-have been updated and committed.
+Update the `version` in `package.json` for the packages we'll release to the **ABQ version**.
+This change will not be committed to git.
 
-Change the package name in [playwright-test/package.json](./packages/playwright-test/package.json) 
-from `@playwright/test` to `@rwx-research/playwright-test-abq`.
+- `playwright-core`
+- `playwright-test`
 
+Run [prepare_release.js](./utils/prepare_release.js):
 ```bash
-node ./utils/workspace.js --ensure-consistent
+node utils/prepare_release.js
+```
+
+Perform a build then release:
+```bash
 npm run build
+npm publish --access=public ./packages/playwright-core
 npm publish --access=public ./packages/playwright-test
 ```
 

--- a/packages/playwright-test/src/abq/version.ts
+++ b/packages/playwright-test/src/abq/version.ts
@@ -19,7 +19,7 @@ import { SpawnedMessageInterface } from '@rwx-research/abq/build/protocol';
 
 export const spawnedMessage: SpawnedMessageInterface = {
   adapterName: 'playwright-abq',
-  adapterVersion: '1.29.100',
+  adapterVersion: '1.30.0-next',
   testFramework: 'playwright',
-  testFrameworkVersion: '1.29.1',
+  testFrameworkVersion: '1.30.0-next',
 };

--- a/utils/prepare_release.js
+++ b/utils/prepare_release.js
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Copyright (c) ReadWriteExecute, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const fs = require("fs");
+const path = require("path");
+const { execSync } = require("child_process");
+
+const packages = {
+  "playwright-core": "@rwx-research/playwright-core-abq",
+  "playwright-test": "@rwx-research/playwright-test-abq"
+};
+
+const spawnedMessage = (function() {
+  const abqVersionTs = path.resolve(__dirname, "..", "packages", "playwright-test", "src", "abq", "version.ts");
+  try {
+    execSync(
+      `tsc ${abqVersionTs} --module commonjs --moduleResolution node --outDir tmp`,
+      {
+        cwd: path.resolve(__dirname, ".."),
+        timeout: 30000
+      }
+    );
+    return require("../tmp/version").spawnedMessage;
+  } catch (e) {
+    console.error("Error resolving spawnedMessage from TypeScript to JavaScript", e);
+    process.exit(1);
+  }
+})();
+
+function checkRootVersion() {
+  const rootPackage = require("../package.json");
+  if (rootPackage.version !== spawnedMessage.testFrameworkVersion) {
+    console.error(`Root package.json version of ${rootPackage.version} should match spawnedMessage test framework version of ${spawnedMessage.testFrameworkVersion}`);
+    process.exit(1);
+  }
+}
+
+function updatePackage(package, newName) {
+  const packageJsonPath = path.resolve(__dirname, "..", "packages", package, "package.json");
+  const packageJson = require(packageJsonPath);
+
+  if (packageJson.version !== spawnedMessage.adapterVersion) {
+    console.error(`${package} version of ${packageJson.version} should match spawnedMessage adapter version of ${spawnedMessage.adapterVersion}`);
+    process.exit(1);
+  }
+
+  packageJson.name = newName;
+
+  console.log(`Updating ${packageJsonPath}`);
+  fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2) + "\n");
+}
+
+console.log("Checking version...");
+checkRootVersion();
+
+console.log("Updating package names...");
+for (const [package, newName] of Object.entries(packages)) {
+  updatePackage(package, newName);
+}
+
+console.log("Done");


### PR DESCRIPTION
We now need to release both `playwright-test` and `playwright-core` packages. This scripts up some of the manual changes to reduce chances for user error.