### PR TITLE
Force null Playwright reporter when using ABQ.

### DIFF
--- a/packages/playwright-test/src/abq/index.ts
+++ b/packages/playwright-test/src/abq/index.ts
@@ -33,11 +33,15 @@ const abqConfig = Abq.getAbqConfiguration();
 
 let abqSocket: Socket | null = null;
 
-export function getAbqSocket() {
+export function getAbqSocket(): Socket {
   if (!abqSocket)
     throw new Error('ABQ socket is not yet initialized.');
 
   return abqSocket;
+}
+
+export function isEnabled(): boolean {
+  return abqConfig.enabled;
 }
 
 export function checkForConfigurationIncompatibility(config: FullConfigInternal, projectFilter: string[]): TestError[] {
@@ -68,7 +72,7 @@ export function checkForConfigurationIncompatibility(config: FullConfigInternal,
   return fatalErrors;
 }
 
-function applyAbqConfiguration(config: FullConfig) {
+export function applyAbqConfiguration(config: FullConfig) {
   if (config.workers !== 1) {
     // eslint-disable-next-line no-console
     console.warn(`Warning: ABQ only supports 1 worker. Overriding configuration value of '${config.workers}'.`);
@@ -80,7 +84,11 @@ function applyAbqConfiguration(config: FullConfig) {
     console.warn(`Warning: ABQ does not support Playwright sharding. Overriding configuration value of '${JSON.stringify(config.shard)}'.`);
     config.shard = null;
   }
+
+  // Disable built-in reporters to use ABQ's reporter.
+  config.reporter = [['null', undefined]];
 }
+
 export async function initialize(rootSuite: Suite): Promise<InitializeResult> {
   if (!abqConfig.enabled) {
     return { status: 'passed', enabled: false, exit: false };

--- a/packages/playwright-test/src/runner.ts
+++ b/packages/playwright-test/src/runner.ts
@@ -166,7 +166,7 @@ export class Runner {
       const prints = r.printsToStdio ? r.printsToStdio() : true;
       return prints;
     });
-    if (reporters.length && !someReporterPrintsToStdio) {
+    if (reporters.length && !someReporterPrintsToStdio && !Abq.isEnabled()) {
       // Add a line/dot/list-mode reporter for convenience.
       // Important to put it first, jsut in case some other reporter stalls onEnd.
       if (list)
@@ -178,8 +178,9 @@ export class Runner {
   }
 
   async runAllTests(options: RunOptions): Promise<FullResult> {
-    this._reporter = await this._createReporter(!!options.listOnly);
     const config = this._configLoader.fullConfig();
+    Abq.applyAbqConfiguration(config);
+    this._reporter = await this._createReporter(!!options.listOnly);
     const result = await raceAgainstTimeout(() => this._run(options), config.globalTimeout);
     let fullResult: FullResult;
     if (result.timedOut) {


### PR DESCRIPTION
Avoid requiring configuration for this, since the Playwright output will be nonsensical (eg. skipped tests, etc). Reporting should be configured via ABQ, not Playwright.