### PR TITLE
Updates for ABQ 1.3.1 in preparation of further releases

### DIFF
--- a/.github/workflows/tests_abq.yml
+++ b/.github/workflows/tests_abq.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-      - run: npm i -g npm
+      - run: npm i
       - run: npm run build
 
       - name: Pull down abq tester harness

--- a/.github/workflows/tests_abq.yml
+++ b/.github/workflows/tests_abq.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   test:
-    runs-on: rwx-ubuntu-latest
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         include:

--- a/.github/workflows/tests_abq.yml
+++ b/.github/workflows/tests_abq.yml
@@ -28,8 +28,11 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-      - run: npm i
+      - run: npm ci
+        env:
+          DEBUG: pw:install
       - run: npm run build
+      - run: npx playwright install --with-deps chromium
 
       - name: Pull down abq tester harness
         run: |

--- a/.github/workflows/tests_abq.yml
+++ b/.github/workflows/tests_abq.yml
@@ -24,23 +24,23 @@ jobs:
       AWS_DEFAULT_REGION: us-east-2
       AWS_DEFAULT_OUTPUT: json
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
-      with:
-        node-version: ${{ matrix.node-version }}
-    - run: npm i -g npm
-    - run: npm run build
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm i -g npm
+      - run: npm run build
 
-    - name: Pull down abq tester harness
-      run: |
-        aws configure set aws_access_key_id ${{ secrets.AWS_S3_ABQ_RELEASES_STAGING_ACCESS_KEY_ID }} --profile staging
-        aws configure set aws_secret_access_key ${{ secrets.AWS_S3_ABQ_RELEASES_STAGING_SECRET_ACCESS_KEY }} --profile staging
-        ABQ_BIN="$PWD/abq-bin"
-        mkdir -p "$ABQ_BIN"
-        aws s3 cp "s3://abq-releases-staging/abq/nightly/linux/x86_64/abq_tester_harness" "$ABQ_BIN/abq_tester_harness" --profile staging
-        chmod 755 "$ABQ_BIN/abq_tester_harness"
-        echo "$ABQ_BIN" >> "$GITHUB_PATH"
+      - name: Pull down abq tester harness
+        run: |
+          aws configure set aws_access_key_id ${{ secrets.AWS_S3_ABQ_RELEASES_STAGING_ACCESS_KEY_ID }} --profile staging
+          aws configure set aws_secret_access_key ${{ secrets.AWS_S3_ABQ_RELEASES_STAGING_SECRET_ACCESS_KEY }} --profile staging
+          ABQ_BIN="$PWD/abq-bin"
+          mkdir -p "$ABQ_BIN"
+          aws s3 cp "s3://abq-releases-staging/abq/nightly/linux/x86_64/abq_tester_harness" "$ABQ_BIN/abq_tester_harness" --profile staging
+          chmod 755 "$ABQ_BIN/abq_tester_harness"
+          echo "$ABQ_BIN" >> "$GITHUB_PATH"
 
-    - name: Run tests
-      run: |
-        node abq-tests/runtests.js
+      - name: Run tests
+        run: |
+          node abq-tests/runtests.js

--- a/.github/workflows/tests_abq.yml
+++ b/.github/workflows/tests_abq.yml
@@ -1,0 +1,46 @@
+name: "tests abq"
+
+on:
+  - push
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # Force terminal colors. @see https://www.npmjs.com/package/colors
+  FORCE_COLOR: 1
+  FLAKINESS_CONNECTION_STRING: ${{ secrets.FLAKINESS_CONNECTION_STRING }}
+
+jobs:
+  test:
+    runs-on: rwx-ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - node-version: 16
+          - node-version: 18
+    env:
+      AWS_DEFAULT_REGION: us-east-2
+      AWS_DEFAULT_OUTPUT: json
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm i -g npm
+    - run: npm run build
+
+    - name: Pull down abq tester harness
+      run: |
+        aws configure set aws_access_key_id ${{ secrets.AWS_S3_ABQ_RELEASES_STAGING_ACCESS_KEY_ID }} --profile staging
+        aws configure set aws_secret_access_key ${{ secrets.AWS_S3_ABQ_RELEASES_STAGING_SECRET_ACCESS_KEY }} --profile staging
+        ABQ_BIN="$PWD/abq-bin"
+        mkdir -p "$ABQ_BIN"
+        aws s3 cp "s3://abq-releases-staging/abq/nightly/linux/x86_64/abq_tester_harness" "$ABQ_BIN/abq_tester_harness" --profile staging
+        chmod 755 "$ABQ_BIN/abq_tester_harness"
+        echo "$ABQ_BIN" >> "$GITHUB_PATH"
+
+    - name: Run tests
+      run: |
+        node abq-tests/runtests.js

--- a/abq-tests/runtests.js
+++ b/abq-tests/runtests.js
@@ -1,0 +1,96 @@
+const cp = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+const BASEPATH = __dirname;
+
+const MANIFEST_RAW_FILE = "manifest.raw.json";
+const RESULTS_RAW_FILE = "results.raw.json";
+
+const MANIFEST_CLEAN_FILE = "manifest.clean.json";
+const RESULTS_CLEAN_FILE = "results.clean.json";
+
+const UPDATE = !!process.env["UPDATE"];
+
+const tests = ["smoketest"];
+
+function cleanMembers(testPath, members) {
+  for (const member of members) {
+    if (member["type"] === "group") {
+      cleanMembers(testPath, member["members"]);
+    } else {
+      console.assert(member["type"] === "test");
+      member["id"] = "STRIPPED";
+    }
+
+    const meta = member["meta"];
+    if ("fileName" in meta) {
+      meta["fileName"] = path.relative(testPath, meta["fileName"]);
+    }
+  }
+}
+
+function cleanManifest(testPath, manifest) {
+  cleanMembers(testPath, manifest["manifest"]["members"]);
+
+  const nativeRunner = manifest["native_runner_specification"];
+  nativeRunner["language_version"] = "STRIPPED";
+  nativeRunner["host"] = "STRIPPED";
+
+  return manifest;
+}
+
+function cleanResults(results) {
+  for (const resultsList of results) {
+    for (const result of resultsList) {
+      result["result"]["runtime"]["Nanoseconds"] = "STRIPPED";
+      result["result"]["stderr"] = "STRIPPED";
+      result["result"]["stdout"] = "STRIPPED";
+    }
+  }
+  return results;
+}
+
+function checkOrUpdate(actual, expectedFile) {
+  fs.writeFileSync(expectedFile, JSON.stringify(actual, null, 2));
+  if (UPDATE || !fs.existsSync(expectedFile)) {
+    cp.execSync(`git add ${expectedFile}`, { stdio: "inherit" });
+  } else {
+    cp.execSync(`git diff --exit-code ${expectedFile}`, { stdio: "inherit" });
+  }
+}
+
+function runTest(testPath) {
+  process.chdir(testPath);
+
+  cp.execSync(`npm install`, { stdio: "inherit" });
+
+  cp.execSync(
+    `abq_tester_harness e2e --results ${RESULTS_RAW_FILE} --manifest ${MANIFEST_RAW_FILE} -- npm test`,
+    {
+      stdio: "inherit",
+    }
+  );
+
+  const rawResults = JSON.parse(
+    fs.readFileSync(RESULTS_RAW_FILE).toString("utf-8")
+  );
+  const rawManifest = JSON.parse(
+    fs.readFileSync(MANIFEST_RAW_FILE).toString("utf-8")
+  );
+
+  fs.rmSync(RESULTS_RAW_FILE);
+  fs.rmSync(MANIFEST_RAW_FILE);
+
+  const manifest = cleanManifest(testPath, rawManifest);
+  const results = cleanResults(rawResults);
+
+  checkOrUpdate(manifest, MANIFEST_CLEAN_FILE);
+  checkOrUpdate(results, RESULTS_CLEAN_FILE);
+}
+
+for (const test of tests) {
+  const testPath = path.join(BASEPATH, test);
+
+  runTest(testPath);
+}

--- a/abq-tests/smoketest/.gitignore
+++ b/abq-tests/smoketest/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+test-results/
+playwright-report/
+*.raw.json

--- a/abq-tests/smoketest/manifest.clean.json
+++ b/abq-tests/smoketest/manifest.clean.json
@@ -1,0 +1,52 @@
+{
+  "manifest": {
+    "members": [
+      {
+        "type": "group",
+        "name": "",
+        "members": [
+          {
+            "type": "group",
+            "name": "tests/test-api.spec.ts",
+            "members": [
+              {
+                "type": "test",
+                "id": "STRIPPED",
+                "tags": [],
+                "meta": {}
+              },
+              {
+                "type": "test",
+                "id": "STRIPPED",
+                "tags": [],
+                "meta": {}
+              }
+            ],
+            "tags": [],
+            "meta": {
+              "fileName": "tests/test-api.spec.ts"
+            }
+          }
+        ],
+        "tags": [],
+        "meta": {}
+      }
+    ],
+    "init_meta": {}
+  },
+  "native_runner_protocol": {
+    "type": "abq_protocol_version",
+    "major": 0,
+    "minor": 2
+  },
+  "native_runner_specification": {
+    "type": "abq_native_runner_specification",
+    "name": "playwright-abq",
+    "version": "1.30.0-next",
+    "test_framework": "playwright",
+    "test_framework_version": "1.30.0-next",
+    "language": "javascript",
+    "language_version": "STRIPPED",
+    "host": "STRIPPED"
+  }
+}

--- a/abq-tests/smoketest/package-lock.json
+++ b/abq-tests/smoketest/package-lock.json
@@ -1,0 +1,37 @@
+{
+  "name": "abqtest-smoketest",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "abqtest-smoketest",
+      "version": "0.0.1",
+      "license": "ISC",
+      "devDependencies": {
+        "@playwright/test": "file:../../packages/playwright-test"
+      }
+    },
+    "../../packages/playwright-test": {
+      "name": "@playwright/test",
+      "version": "1.30.0-next",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@rwx-research/abq": "0.1.0-alpha.11",
+        "@types/node": "*",
+        "playwright-core": "1.30.0-next"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "resolved": "../../packages/playwright-test",
+      "link": true
+    }
+  }
+}

--- a/abq-tests/smoketest/package.json
+++ b/abq-tests/smoketest/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "abqtest-smoketest",
+  "version": "0.0.1",
+  "scripts": {
+    "test": "playwright test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "@playwright/test": "file:../../packages/playwright-test"
+  },
+  "overrides": {
+    "playwright-core": "file:../../packages/playwright-core"
+  }
+}

--- a/abq-tests/smoketest/playwright.config.ts
+++ b/abq-tests/smoketest/playwright.config.ts
@@ -1,0 +1,13 @@
+/* eslint-disable notice/notice */
+
+import { defineConfig } from "@playwright/test";
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  fullyParallel: true,
+  shard: null,
+  workers: process.env.ABQ_RUNNER ? 1 : undefined,
+  reporter: "line",
+});

--- a/abq-tests/smoketest/results.clean.json
+++ b/abq-tests/smoketest/results.clean.json
@@ -1,0 +1,50 @@
+[
+  [
+    {
+      "source": {
+        "runner": [
+          0,
+          1
+        ],
+        "is_singleton": true,
+        "has_stdout_reporters": false
+      },
+      "result": {
+        "status": "Success",
+        "id": "afd76d7bd7b042a55940-50a2efd630ad4859976e",
+        "display_name": "homepage has title and links to intro page",
+        "output": "",
+        "runtime": {
+          "Nanoseconds": "STRIPPED"
+        },
+        "meta": {},
+        "stderr": "STRIPPED",
+        "stdout": "STRIPPED"
+      }
+    }
+  ],
+  [
+    {
+      "source": {
+        "runner": [
+          0,
+          1
+        ],
+        "is_singleton": true,
+        "has_stdout_reporters": false
+      },
+      "result": {
+        "status": "Success",
+        "id": "afd76d7bd7b042a55940-6efb1d0bf2188128ca22",
+        "display_name": "homepage has title and links to intro page 2",
+        "output": "",
+        "runtime": {
+          "Nanoseconds": "STRIPPED"
+        },
+        "meta": {},
+        "stderr": "STRIPPED",
+        "stdout": "STRIPPED"
+      }
+    }
+  ]
+]

--- a/abq-tests/smoketest/tests/test-api.spec.ts
+++ b/abq-tests/smoketest/tests/test-api.spec.ts
@@ -1,0 +1,50 @@
+/* eslint-disable notice/notice */
+
+/**
+ * In this script, we will login and run a few tests that use GitHub API.
+ *
+ * Steps summary
+ * 1. Create a new repo.
+ * 2. Run tests that programmatically create new issues.
+ * 3. Delete the repo.
+ */
+
+import { test, expect } from "@playwright/test";
+
+test("homepage has title and links to intro page", async ({ page }) => {
+  await page.goto("https://playwright.dev/");
+
+  // Expect a title "to contain" a substring.
+  await expect(page).toHaveTitle(/Playwright/);
+
+  // create a locator
+  const getStarted = page.getByRole("link", { name: "Get started" });
+
+  // Expect an attribute "to be strictly equal" to the value.
+  await expect(getStarted).toHaveAttribute("href", "/docs/intro");
+
+  // Click the get started link.
+  await getStarted.click();
+
+  // Expects the URL to contain intro.
+  await expect(page).toHaveURL(/.*intro/);
+});
+
+test("homepage has title and links to intro page 2", async ({ page }) => {
+  await page.goto("https://playwright.dev/");
+
+  // Expect a title "to contain" a substring.
+  await expect(page).toHaveTitle(/Playwright/);
+
+  // create a locator
+  const getStarted = page.getByRole("link", { name: "Get started" });
+
+  // Expect an attribute "to be strictly equal" to the value.
+  await expect(getStarted).toHaveAttribute("href", "/docs/intro");
+
+  // Click the get started link.
+  await getStarted.click();
+
+  // Expects the URL to contain intro.
+  await expect(page).toHaveURL(/.*intro/);
+});

--- a/packages/playwright-test/src/abq/index.ts
+++ b/packages/playwright-test/src/abq/index.ts
@@ -33,15 +33,11 @@ const abqConfig = Abq.getAbqConfiguration();
 
 let abqSocket: Socket | null = null;
 
-export function getAbqSocket(): Socket {
+export function getAbqSocket() {
   if (!abqSocket)
     throw new Error('ABQ socket is not yet initialized.');
 
   return abqSocket;
-}
-
-export function isEnabled(): boolean {
-  return abqConfig.enabled;
 }
 
 export function checkForConfigurationIncompatibility(config: FullConfigInternal, projectFilter: string[]): TestError[] {
@@ -72,7 +68,7 @@ export function checkForConfigurationIncompatibility(config: FullConfigInternal,
   return fatalErrors;
 }
 
-export function applyAbqConfiguration(config: FullConfig) {
+function applyAbqConfiguration(config: FullConfig) {
   if (config.workers !== 1) {
     // eslint-disable-next-line no-console
     console.warn(`Warning: ABQ only supports 1 worker. Overriding configuration value of '${config.workers}'.`);
@@ -84,11 +80,7 @@ export function applyAbqConfiguration(config: FullConfig) {
     console.warn(`Warning: ABQ does not support Playwright sharding. Overriding configuration value of '${JSON.stringify(config.shard)}'.`);
     config.shard = null;
   }
-
-  // Disable built-in reporters to use ABQ's reporter.
-  config.reporter = [['null', undefined]];
 }
-
 export async function initialize(rootSuite: Suite): Promise<InitializeResult> {
   if (!abqConfig.enabled) {
     return { status: 'passed', enabled: false, exit: false };

--- a/packages/playwright-test/src/runner.ts
+++ b/packages/playwright-test/src/runner.ts
@@ -166,7 +166,7 @@ export class Runner {
       const prints = r.printsToStdio ? r.printsToStdio() : true;
       return prints;
     });
-    if (reporters.length && !someReporterPrintsToStdio && !Abq.isEnabled()) {
+    if (reporters.length && !someReporterPrintsToStdio) {
       // Add a line/dot/list-mode reporter for convenience.
       // Important to put it first, jsut in case some other reporter stalls onEnd.
       if (list)
@@ -178,9 +178,8 @@ export class Runner {
   }
 
   async runAllTests(options: RunOptions): Promise<FullResult> {
-    const config = this._configLoader.fullConfig();
-    Abq.applyAbqConfiguration(config);
     this._reporter = await this._createReporter(!!options.listOnly);
+    const config = this._configLoader.fullConfig();
     const result = await raceAgainstTimeout(() => this._run(options), config.globalTimeout);
     let fullResult: FullResult;
     if (result.timedOut) {


### PR DESCRIPTION
- Revert #7. This is no longer needed since ABQ will pass-through test output.
- Add a smoke test for playwright-abq using the worker harness.